### PR TITLE
fix: reference correct url and org name

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Mewyuna/bunnyfetch/cmd"
+	"github.com/Rosettea/bunnyfetch/cmd"
 )
+
 func main() {
 	if err := cmd.RootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }
-


### PR DESCRIPTION
Running the install instructions in README.md was failing as `main.go` was still referencing the old org name.