### PR TITLE
docs: change go get command to go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 # Install
 Binaries are provided at the releases page [here](https://github.com/Rosettea/Bunnyfetch/releases).
-Or, you can just run `go get -u github.com/Rosettea/bunnyfetch`
+Or, you can just run `go install github.com/Rosettea/bunnyfetch@latest`
 
 ## Manual Compile
 ```sh


### PR DESCRIPTION
'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation